### PR TITLE
Add fields to interface definition

### DIFF
--- a/TypeScripter.Tests/Fields.cs
+++ b/TypeScripter.Tests/Fields.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+using TypeScripter.Tests;
+
+namespace TypeScripter.Fields
+{
+    #region Example Constructs
+    public class Elephant
+    {
+        public readonly string Name;
+        public readonly int Age;
+
+        public Elephant(string name, int age)
+        {
+            this.Name = name;
+            this.Age = age;
+        }
+
+    }
+    #endregion
+
+    [TestFixture]
+    public class ReadonlyFieldsUsage : Test
+    {
+        [Test]
+        public void OutputTest()
+        {
+            var scripter = new TypeScripter.Scripter();
+            var output = scripter
+                .AddType(typeof(Elephant))
+                .ToString();
+
+            ValidateTypeScript(output);
+        }
+
+        [Test]
+        public void TestThatFieldIsRendered()
+        {
+            var scripter = new TypeScripter.Scripter();
+            var output = scripter
+                .AddType(typeof(Elephant))
+                .ToString();
+
+            Assert.True(output.Contains("Name"));
+        }
+    }
+
+}
+

--- a/TypeScripter.Tests/TypeScripter.Tests.csproj
+++ b/TypeScripter.Tests/TypeScripter.Tests.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyTest.cs" />
+    <Compile Include="Fields.cs" />
     <Compile Include="InheritanceTest.cs" />
     <Compile Include="GenericsTest.cs" />
     <Compile Include="Examples.cs" />

--- a/TypeScripter/Readers/DefaultTypeReader.cs
+++ b/TypeScripter/Readers/DefaultTypeReader.cs
@@ -9,7 +9,7 @@ using TypeScripter.TypeScript;
 
 namespace TypeScripter.Readers
 {
-	public class DefaultTypeReader : ITypeReader
+    public class DefaultTypeReader : ITypeReader
 	{
 		#region ITypeReader
 		public virtual IEnumerable<Type> GetTypes(Assembly assembly)
@@ -18,6 +18,12 @@ namespace TypeScripter.Readers
 				.Where(x => x.IsPublic)
 				.Where(x => !x.IsPointer);
 		}
+
+	    public virtual IEnumerable<FieldInfo> GetFields(Type type)
+	    {
+            // Backwards compatible implementation.
+	        return new FieldInfo[0];
+	    }
 
 		public virtual IEnumerable<PropertyInfo> GetProperties(Type type)
 		{

--- a/TypeScripter/Readers/ITypeReader.cs
+++ b/TypeScripter/Readers/ITypeReader.cs
@@ -8,6 +8,7 @@ namespace TypeScripter.Readers
 	{
 		IEnumerable<MethodInfo> GetMethods(Type type);
 		IEnumerable<ParameterInfo> GetParameters(MethodInfo method);
+        IEnumerable<FieldInfo> GetFields(Type type);
 		IEnumerable<PropertyInfo> GetProperties(Type type);
 		IEnumerable<Type> GetTypes(Assembly assembly);
 	}


### PR DESCRIPTION
I have some idempotent models that use read-only fields that I would like to generate definitions for.
