### PR TITLE
better  Dictionary<,> handling (using inline interfaces)

### DIFF
--- a/TypeScripter.Tests/Dictionaries.cs
+++ b/TypeScripter.Tests/Dictionaries.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using TypeScripter.Tests;
+
+namespace TypeScripter.Dictionaries
+{
+	#region Example Constructs
+	public class Order
+	{
+	    public Dictionary<string, OrderLineItem> OrderLines { get; set; }
+
+	    public Order(Dictionary<string, OrderLineItem> orderLines)
+	    {
+	        OrderLines = orderLines;
+	    }
+	}
+
+    public class OrderLineItem
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+	#endregion
+
+	[TestFixture]
+	public class Dictionaries : Test
+	{
+		[Test]
+		public void OutputTest()
+		{
+			var scripter = new TypeScripter.Scripter();
+			var output = scripter
+				.AddType(typeof(Order))
+				.ToString();
+
+			ValidateTypeScript(output);
+		}
+
+        [Test]
+        public void TestThatDictionaryIsRendered()
+        {
+            var scripter = new TypeScripter.Scripter();
+            var output = scripter
+                .AddType(typeof(Order))
+                .ToString();
+
+            // we want to descent to generic type
+            Assert.True(output.Contains("OrderLineItem"));
+
+            // inline interface for dictionary is generated
+            Assert.True(output.Contains("OrderLines: {[key: string]: TypeScripter.Dictionaries.OrderLineItem;}"));
+        }
+
+
+    }
+}
+

--- a/TypeScripter.Tests/TypeScripter.Tests.csproj
+++ b/TypeScripter.Tests/TypeScripter.Tests.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyTest.cs" />
+    <Compile Include="Dictionaries.cs" />
     <Compile Include="Fields.cs" />
     <Compile Include="InheritanceTest.cs" />
     <Compile Include="GenericsTest.cs" />

--- a/TypeScripter/TypeScript/TsFormatter.cs
+++ b/TypeScripter/TypeScript/TsFormatter.cs
@@ -142,7 +142,10 @@ namespace TypeScripter.TypeScript
 				using (Indent())
 				{
                     foreach (var property in tsInterface.Properties.OrderBy(x => x.Name))
-						this.Write(this.Format(property));
+						this.Write(this.Format(property, indent: true));
+
+                    foreach (var property in tsInterface.IndexerProperties.OrderBy(x => x.Name))
+                        this.Write(this.Format(property, indent: true));
 
                     foreach (var function in tsInterface.Functions.OrderBy(x => x.Name))
 						this.Write(this.Format(function));
@@ -155,18 +158,37 @@ namespace TypeScripter.TypeScript
 			}
 		}
 
-		public virtual string Format(TsProperty property)
+		public virtual string Format(TsProperty property, bool indent)
 		{
 			using (var sbc = new StringBuilderContext(this))
 			{
-				this.WriteIndent();
+                if (indent)
+				    this.WriteIndent();
+
 				this.Write("{0}: {1};", Format(property.Name), Format(property.Type));
-				this.WriteNewline();
+
+                if (indent)
+				    this.WriteNewline();
 				return sbc.ToString();
 			}
 		}
 
-		public virtual string Format(TsFunction function)
+        public virtual string Format(TsIndexerProperty property, bool indent)
+        {
+            using (var sbc = new StringBuilderContext(this))
+            {
+                if (indent)
+                    this.WriteIndent();
+
+                this.Write("[{0}: {1}]: {2};", Format(property.Name), Format(property.IndexerType), Format(property.ReturnType));
+
+                if (indent)
+                    this.WriteNewline();
+                return sbc.ToString();
+            }
+        }
+
+        public virtual string Format(TsFunction function)
 		{
 			using (var sbc = new StringBuilderContext(this))
 			{
@@ -191,6 +213,8 @@ namespace TypeScripter.TypeScript
 		{
 			if (tsType is TsGenericType)
 				return Format((TsGenericType)tsType);
+		    if (tsType is TsInlineInterface)
+		        return Format((TsInlineInterface)tsType);
 			return tsType.Name.FullName;
 		}
 
@@ -253,6 +277,22 @@ namespace TypeScripter.TypeScript
 		{
 			return string.Format("{0}{1}", tsGenericType.Name.FullName, tsGenericType.TypeArguments.Count > 0 ? string.Format("<{0}>", string.Join(", ", tsGenericType.TypeArguments.Select(Format))) : string.Empty);
 		}
+
+	    public virtual string Format(TsInlineInterface tsInterface)
+	    {
+            using (var sbc = new StringBuilderContext(this))
+            {
+                this.Write("{");
+                foreach (var property in tsInterface.Properties.OrderBy(x => x.Name))
+                    this.Write(this.Format(property, indent: false));
+
+                foreach (var property in tsInterface.IndexerProperties.OrderBy(x => x.Name))
+                    this.Write(this.Format(property, indent: false));
+
+                this.Write("}");
+                return sbc.ToString();
+            }
+        }
 
 		public virtual string Format(TsName name)
 		{

--- a/TypeScripter/TypeScript/TsIndexerProperty.cs
+++ b/TypeScripter/TypeScript/TsIndexerProperty.cs
@@ -1,0 +1,34 @@
+﻿namespace TypeScripter.TypeScript
+{
+	public class TsIndexerProperty : TsObject
+	{
+		#region Properties
+		public TsType IndexerType
+		{
+			get;
+			set;
+		}
+
+	    public TsType ReturnType
+	    {
+	        get;
+	        set;
+	    }
+		#endregion
+
+		#region Creation
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="name">The interface name</param>
+		/// <param name="indexerType">Type used in index</param>
+		/// <param name="returnType">The indexer return type</param>
+		public TsIndexerProperty(TsName name, TsType indexerType, TsType returnType)
+			: base(name)
+		{
+		    this.IndexerType = indexerType;
+		    this.ReturnType = returnType;
+		}
+		#endregion
+	}
+}

--- a/TypeScripter/TypeScript/TsInlineInterface.cs
+++ b/TypeScripter/TypeScript/TsInlineInterface.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+
+namespace TypeScripter.TypeScript
+{
+	/// <summary>
+	/// A class representing inline type defintion
+	/// Ex. var a : >>>>>{ b: string; c: number, [idx: string]: string }<<<<<
+	/// </summary>
+	public sealed class TsInlineInterface : TsType
+	{
+		/// <summary>
+		/// The interface properties
+		/// </summary>
+		#region Properties
+		public IList<TsProperty> Properties
+		{
+			get;
+			private set;
+		}
+
+        public IList<TsIndexerProperty> IndexerProperties
+        {
+            get;
+            private set;
+        }
+        #endregion
+
+        #region Creation
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="name">The interface name</param>
+        public TsInlineInterface(TsName name)
+			: base(name)
+		{
+			this.Properties = new List<TsProperty>();
+            this.IndexerProperties = new List<TsIndexerProperty>();
+		}
+		#endregion
+	}
+}

--- a/TypeScripter/TypeScript/TsInterface.cs
+++ b/TypeScripter/TypeScript/TsInterface.cs
@@ -21,6 +21,12 @@ namespace TypeScripter.TypeScript
 			private set;
 		}
 
+	    public IList<TsIndexerProperty> IndexerProperties
+	    {
+	        get;
+	        private set;
+	    }
+
 		/// <summary>
 		/// The interface functions
 		/// </summary>
@@ -60,6 +66,7 @@ namespace TypeScripter.TypeScript
 			this.TypeParameters = new List<TsTypeParameter>();
 			this.BaseInterfaces = new List<TsType>();
 			this.Properties = new List<TsProperty>();
+            this.IndexerProperties = new List<TsIndexerProperty>();
 			this.Functions = new List<TsFunction>();
 		}
 		#endregion

--- a/TypeScripter/TypeScripter.csproj
+++ b/TypeScripter/TypeScripter.csproj
@@ -50,6 +50,8 @@
     <Compile Include="TypeExtensions.cs" />
     <Compile Include="TypeScript\TsGenericType.cs" />
     <Compile Include="TypeScript\TsFunction.cs" />
+    <Compile Include="TypeScript\TsInlineInterface.cs" />
+    <Compile Include="TypeScript\TsIndexerProperty.cs" />
     <Compile Include="TypeScript\TsTypeParameter.cs" />
     <Compile Include="TypeScript\TsParameter.cs" />
     <Compile Include="TypeScript\TsName.cs" />


### PR DESCRIPTION
This PR covers following definition:

```
public class Settings {
     public Dictionary<string, string> BasicSettings { get; set; }
}
```

Previously it was mapped as System.Collections.Generic.Dictionary and other system classes was included in output file (ex. X509Certificate ;-) ). 

**We only support Dictionaries with string as key.**

For class:

``` cs
public class Order
    {
        public Dictionary<string, OrderLineItem> OrderLines { get; set; }

        public Order(Dictionary<string, OrderLineItem> orderLines)
        {
            OrderLines = orderLines;
        }
    }

    public class OrderLineItem
    {
        public string Id { get; set; }
        public string Name { get; set; }
    }

```

it generates:

``` ts
declare module TypeScripter.Dictionaries {
    interface Order  {
        OrderLines: {[key: string]: TypeScripter.Dictionaries.OrderLineItem;};
    }

    interface OrderLineItem  {
        Id: string;
        Name: string;
    }
}
```

Test is included + it passes on both .NET Core and full .NET. 
