### PR TITLE
support for enums as strings (using string literal types)

### DIFF
--- a/Src/TypeScripter.Tests/Enums.cs
+++ b/Src/TypeScripter.Tests/Enums.cs
@@ -1,0 +1,93 @@
+﻿using NUnit.Framework;
+using TypeScripter.TypeScript;
+
+namespace TypeScripter.Tests
+{
+
+    #region Example Constructs
+    public class Person
+    {
+        public readonly Sex sex;
+
+        public Person(Sex sex)
+        {
+            this.sex = sex;
+        }
+    }
+
+    public enum Sex
+    {
+        Male,
+        Female,
+        Unknown
+    }
+    #endregion
+
+    [TestFixture]
+    public class Enums : Test
+    {
+        [Test]
+        public void OutputTest()
+        {
+            var scripter = new TypeScripter.Scripter();
+            var output = scripter
+                .AddType(typeof(Person))
+                .ToString();
+
+            ValidateTypeScript(output);
+        }
+
+        [Test]
+        public void TestThatEnumIsRendered()
+        {
+            var scripter = new TypeScripter.Scripter();
+            var output = scripter
+                .AddType(typeof(Person))
+                .ToString();
+
+            Assert.True(output.Contains("Female"));
+            Assert.True(output.Contains("Male"));
+            Assert.True(output.Contains("Unknown"));
+            Assert.True(output.Contains("sex: TypeScripter.Tests.Sex"));
+        }
+
+        [Test]
+        public void TestThatEnumIsRenderedAsString()
+        {
+            var scripter = new TypeScripter.Scripter();
+            var output = scripter
+                .UsingFormatter(new TsFormatter
+                {
+                    EnumsAsString = true
+                })
+                .AddType(typeof(Person))
+                .ToString();
+
+            Assert.True(output.Contains("type Sex = 'Female' | 'Male' | 'Unknown'"));
+            Assert.True(output.Contains("sex: TypeScripter.Tests.Sex;"));
+        }
+
+        [Test]
+        public void EnumValueIsValidated()
+        {
+            var scripter = new TypeScripter.Scripter();
+            var output = scripter
+                .UsingFormatter(new TsFormatter
+                {
+                    EnumsAsString = true
+                })
+                .AddType(typeof(Person))
+                .ToString();
+
+            var code = "\n var x: TypeScripter.Tests.Person; \n" +
+                       "x.sex = 'test'";
+
+            AssertNotValidTypeScript(output + code);
+
+            code = "\n var x: TypeScripter.Tests.Person; \n" +
+                       "x.sex = 'Female'";
+
+            ValidateTypeScript(output + code);
+        }
+    }
+}

--- a/Src/TypeScripter.Tests/Test.cs
+++ b/Src/TypeScripter.Tests/Test.cs
@@ -33,6 +33,13 @@ namespace TypeScripter.Tests
         {
             ValidateTypeScript(typeScript.ToString());
         }
+
+        protected void AssertNotValidTypeScript(string typeScript)
+        {
+            Console.WriteLine(typeScript);
+            var result = TypeScriptCompiler.Compile(typeScript);
+            Assert.AreNotEqual(0, result.ReturnCode, result.Output);
+        }
     }
 }
 

--- a/Src/TypeScripter.Tests/TypeScripter.Tests.csproj
+++ b/Src/TypeScripter.Tests/TypeScripter.Tests.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="AssemblyTest.cs" />
     <Compile Include="Dictionaries.cs" />
+    <Compile Include="Enums.cs" />
     <Compile Include="Examples\Ex5.Formatters.cs" />
     <Compile Include="Examples\Ex4.TypeReaders.cs" />
     <Compile Include="Examples\Ex3.Generics.cs" />

--- a/Src/TypeScripter/TypeScript/TsFormatter.cs
+++ b/Src/TypeScripter/TypeScript/TsFormatter.cs
@@ -97,6 +97,14 @@ namespace TypeScripter.TypeScript
             get;
             private set;
         }
+
+        /// <summary>
+        /// Enums are represented as strings not as numbers
+        /// </summary>
+        public bool EnumsAsString
+        {
+            get; set;
+        }
         #endregion
 
         #region Creation
@@ -282,6 +290,48 @@ namespace TypeScripter.TypeScript
         /// <param name="tsEnum">The enumeration</param>
         /// <returns>The string representation of the enumeration</returns>
         public virtual string Format(TsEnum tsEnum)
+        {
+            if (this.EnumsAsString)
+            {
+                return this.FormatEnumAsStrings(tsEnum);
+            }
+            else
+            {
+                return this.FormatEnumAsIntegers(tsEnum);
+            }
+        }
+
+        /// <summary>
+        /// Formats an enumeration as string
+        /// </summary>
+        /// <param name="tsEnum">The enumeration</param>
+        /// <returns>The string representation of the enumeration</returns>
+        protected string FormatEnumAsStrings(TsEnum tsEnum)
+        {
+            using (var sbc = new StringBuilderContext(this))
+            {
+                this.WriteIndent();
+                this.Write("type {0} = ", Format(tsEnum.Name));
+                var values = tsEnum.Values.OrderBy(x => x.Key).ToArray();
+                for (int i = 0; i < values.Length; i++)
+                {
+                    var postFix = i < values.Length - 1 ? " | " : string.Empty;
+                    var entry = values[i];
+                    this.Write("\'{0}\'{1}", entry.Key, postFix);
+                }
+                this.Write(";");
+                this.WriteNewline();
+                return sbc.ToString();
+            }
+        }
+
+
+        /// <summary>
+        /// Formats an enumaration as integers
+        /// </summary>
+        /// <param name="tsEnum">The enumeration</param>
+        /// <returns>The string representation of the enumeration</returns>
+        protected string FormatEnumAsIntegers(TsEnum tsEnum)
         {
             using (var sbc = new StringBuilderContext(this))
             {


### PR DESCRIPTION
The original idea for this feature is that we are serialize enums as strings instead of integers. Sometimes we also use EnumFlags (it is serialized as: EnumValue1,EnumValue2)

C# code example:

``` cs
public enum AnimalType {
   Mammal, 
   Reptile

}
public class Animal {
   public AnimalType Type { get; set; }
}
```

First approach: simply chage value type to string. 

``` ts
interface Animal {
    Type: string
}
```

But then we don't have autocomplete for possible values. 

Second approach: generate files with possible values:

``` ts
interface Animal {
   Type: string
}

var AnimalTypes = {
  Mammal: "Mammal"
}
```

It allows us to write: 

``` ts
var a: Animal;
a.Type = AnimalTypes.Mammal;
```

However:
- we have to know where the constants are defined 
- user can pass his own magic string (and we don't verify this)
- code can't be put into *.d.ts file as AnimalTypes compiles to:

``` js
var AnimalTypes = {
    Mammal: "Mammal"
};
```

so we can't easily reuse current architecture. 

Final solution: use string literal types. We end up with following code:

``` ts
type AnimalTypes = 'Mammal' | 'Reptile';
```

Advantages:
- it compiles to empty content
- user can't supply invalid values (however he can cast value to type -  it allows hack code to supply enum flags)
- since we know all possible values IDE can display autocomplete list - right now it isn't working in r#, but I've already reported this as feature request: https://youtrack.jetbrains.com/issue/RSRP-460014

**To avoid breaking backwards compabillity this new behavior is configurable on TsFormatter using EnumsAsString flag.** 

``` cs
 scripter
     .UsingFormatter(new TsFormatter
        {
                    EnumsAsString = true
         })
       .AddType(typeof(Person))
```
