### PR TITLE
Nullable types support

### DIFF
--- a/Src/TypeScripter.Tests/Dictionaries.cs
+++ b/Src/TypeScripter.Tests/Dictionaries.cs
@@ -2,7 +2,7 @@
 using NUnit.Framework;
 using TypeScripter.Tests;
 
-namespace TypeScripter
+namespace TypeScripter.Tests
 {
     #region Example Constructs
     public class Order
@@ -66,11 +66,11 @@ namespace TypeScripter
             ValidateTypeScript(output);
 
             // inline interfaces for dictionaries are generated
-            Assert.True(output.Contains("LinesByIndex: {[key: number]: TypeScripter.OrderLineItem;}"));
-            Assert.True(output.Contains("OrderLines: {[key: string]: TypeScripter.OrderLineItem;}"));
+            Assert.True(output.Contains("LinesByIndex: {[key: number]: TypeScripter.Tests.OrderLineItem;}"));
+            Assert.True(output.Contains("OrderLines: {[key: string]: TypeScripter.Tests.OrderLineItem;}"));
             Assert.True(output.Contains("SimpleDict1: {[key: string]: string;}"));
             Assert.True(output.Contains("SimpleDict2: {[key: number]: number;}"));
-            Assert.True(output.Contains("SimpleDict3: TypeScripter.OrderDictionary;"));
+            Assert.True(output.Contains("SimpleDict3: TypeScripter.Tests.OrderDictionary;"));
         }
     }
 }

--- a/Src/TypeScripter.Tests/NullableTypes.cs
+++ b/Src/TypeScripter.Tests/NullableTypes.cs
@@ -1,0 +1,50 @@
+﻿using NUnit.Framework;
+using TypeScripter.TypeScript;
+
+namespace TypeScripter.Tests
+{
+
+    #region Example Constructs
+    public class TypeWithNullables
+    {
+        public Enum1? Property1 { get; set; }
+        public int? IntProperty { get; set; }
+    }
+
+    public enum Enum1
+    {
+        Value1,
+        Value2,
+        Value3
+    }
+    #endregion
+
+    [TestFixture]
+    public class NullableTypes : Test
+    {
+        [Test]
+        public void CanOutputEnums()
+        {
+            var scripter = new TypeScripter.Scripter();
+            var output = scripter
+                .AddType(typeof(TypeWithNullables))
+                .ToString();
+
+            ValidateTypeScript(output);
+        }
+
+        [Test]
+        public void TestThatNullableTypeIsRendered()
+        {
+            var scripter = new TypeScripter.Scripter();
+            var output = scripter
+                .AddType(typeof(TypeWithNullables))
+                .ToString();
+
+            Assert.True(output.Contains("const enum Enum1"), "Underlaying enum should be resolved");
+            Assert.True(output.Contains("IntProperty?: number"));
+            Assert.True(output.Contains("Property1?: TypeScripter.Tests.Enum1"));
+        }
+
+    }
+}

--- a/Src/TypeScripter.Tests/TypeScripter.Tests.csproj
+++ b/Src/TypeScripter.Tests/TypeScripter.Tests.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="Assemblies.cs" />
     <Compile Include="Dictionaries.cs" />
+    <Compile Include="NullableTypes.cs" />
     <Compile Include="Enums.cs" />
     <Compile Include="Examples\Ex5.Formatters.cs" />
     <Compile Include="Examples\Ex4.TypeReaders.cs" />

--- a/Src/TypeScripter/Scripter.cs
+++ b/Src/TypeScripter/Scripter.cs
@@ -464,11 +464,18 @@ namespace TypeScripter
         protected virtual TsProperty Resolve(PropertyInfo property)
         {
             TsType propertyType;
+            bool optional = false;
             var propertyTypeInfo = property.PropertyType.GetTypeInfo();
-            if (propertyTypeInfo.IsGenericType && !propertyTypeInfo.IsGenericTypeDefinition && propertyTypeInfo.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+            if (propertyTypeInfo.IsGenericType && propertyTypeInfo.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                var genericArguments = propertyTypeInfo.GetGenericArguments();
+                propertyType = this.Resolve(genericArguments[0]);
+                optional = true;
+            }
+            else if (propertyTypeInfo.IsGenericType && !propertyTypeInfo.IsGenericTypeDefinition && propertyTypeInfo.GetGenericTypeDefinition() == typeof(Dictionary<,>))
             {
                 // find type used for dictionary values
-                var genericArguments = property.PropertyType.GetTypeInfo().GetGenericArguments();
+                var genericArguments = propertyTypeInfo.GetGenericArguments();
                 var keyType = genericArguments[0];
                 var valueType = genericArguments[1];
                 var tsKeyType = this.Resolve(keyType);
@@ -481,7 +488,7 @@ namespace TypeScripter
             {
                 propertyType = Resolve(property.PropertyType);
             }
-            return new TsProperty(GetName(property), propertyType);
+            return new TsProperty(GetName(property), propertyType, optional);
         }
 
         /// <summary>

--- a/Src/TypeScripter/TypeScript/TsFormatter.cs
+++ b/Src/TypeScripter/TypeScript/TsFormatter.cs
@@ -221,7 +221,7 @@ namespace TypeScripter.TypeScript
         {
             using (var sbc = new StringBuilderContext(this))
             {
-                this.Write("{0}: {1};", Format(property.Name), Format(property.Type));
+                this.Write("{0}{1}: {2};", Format(property.Name), property.Optional?"?":"", Format(property.Type));
                 return sbc.ToString();
             }
         }

--- a/Src/TypeScripter/TypeScript/TsProperty.cs
+++ b/Src/TypeScripter/TypeScript/TsProperty.cs
@@ -37,11 +37,12 @@ namespace TypeScripter.TypeScript
         /// </summary>
         /// <param name="name">The interface name</param>
         /// <param name="type">The type name</param>
-        public TsProperty(TsName name, TsType type)
+        /// <param name="optional">Indicates optional property</param>
+        public TsProperty(TsName name, TsType type, bool optional = false)
             : base(name)
         {
             this.Type = type;
-            this.Optional = false;
+            this.Optional = optional;
         }
         #endregion
     }


### PR DESCRIPTION
Render nullable type as optional property. 

Ex.:

``` cs
 public class TypeWithNullables
    {
        public Enum1? Property1 { get; set; }
        public int? IntProperty { get; set; }
    }

    public enum Enum1
    {
        Value1,
        Value2,
        Value3
    }
```

Produces:

``` ts

declare module TypeScripter.Tests {
    const enum Enum1 {
        Value1 = 0,
        Value2 = 1,
        Value3 = 2
    }
    interface TypeWithNullables  {
        IntProperty?: number;
        Property1?: TypeScripter.Tests.Enum1;
    }

}

```
