### PR TITLE
support for structs - avoid ValueType type

### DIFF
--- a/Src/TypeScripter.Tests/Structs.cs
+++ b/Src/TypeScripter.Tests/Structs.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using TypeScripter.TypeScript;
+using TypeScripter.Readers;
+
+namespace TypeScripter.Tests
+{
+    [TestFixture]
+    public class Structs : Test
+    {
+        #region Internal Constructs
+        public struct TestStruct
+        {
+            public string Lastname { get; set; }
+            public string Firstname;
+        }
+        #endregion
+
+        [Test]
+        public void CanOutputStructs()
+        {
+            var output = new StringBuilder();
+            output.Append(
+                new TypeScripter.Scripter()
+                    .AddType(typeof(TestStruct))
+            );
+            output.AppendLine("var foo: TypeScripter.Tests.TestStruct;");
+
+            ValidateTypeScript(output);
+            
+            var outputAsString = output.ToString();
+
+            Assert.True(outputAsString.Contains("interface TestStruct  {"));
+            Assert.False(outputAsString.Contains("ValueType"));
+            Assert.True(outputAsString.Contains("Firstname: string"));
+            Assert.True(outputAsString.Contains("Lastname: string"));
+        }
+    }
+}
+

--- a/Src/TypeScripter.Tests/TypeScripter.Tests.csproj
+++ b/Src/TypeScripter.Tests/TypeScripter.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Examples\Ex2.Inheritance.cs" />
     <Compile Include="Examples\Ex1.BasicUsage.cs" />
     <Compile Include="Fields.cs" />
+    <Compile Include="Structs.cs" />
     <Compile Include="Inheritance.cs" />
     <Compile Include="Generics.cs" />
     <Compile Include="Test.cs" />

--- a/Src/TypeScripter/Scripter.cs
+++ b/Src/TypeScripter/Scripter.cs
@@ -77,6 +77,7 @@ namespace TypeScripter
             };
 
             this.RegisterTypeMapping(CreateGenericDictionaryType(), typeof(Dictionary<,>));
+            this.RegisterTypeMapping(TsPrimitive.Any, typeof(ValueType));
 
             // initialize the scripter with default implementations
             this.Reader = new TypeReader();


### PR DESCRIPTION
Actually this can be done by using TypeFilter but in general I don't think we need typings for System.ValueType type. 

Previously:

``` ts
declare module TypeScripter.Tests {
    interface TestStruct extends System.ValueType {
        Firstname: string;
        Lastname: string;
    }

}
declare module System {
    interface ValueType  {
        Equals(obj: any): boolean;
        GetHashCode(): number;
        ToString(): string;
    }

}
var foo: TypeScripter.Tests.TestStruct;
```

With this change:

``` ts
declare module TypeScripter.Tests {
    interface TestStruct  {
        Firstname: string;
        Lastname: string;
    }

}
var foo: TypeScripter.Tests.TestStruct;
```
