### PR TITLE
support for custom type mappiing

### DIFF
--- a/Src/TypeScripter.Tests/RegisterTypeMapping.cs
+++ b/Src/TypeScripter.Tests/RegisterTypeMapping.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using TypeScripter.Tests;
+using TypeScripter.TypeScript;
+
+namespace TypeScripter.Tests
+{
+    [TestFixture]
+    public class RegisterTypeMapping : Test
+    {
+        public class Developer
+        {
+            public HashSet<string> Skills { get; set; }
+            public LinkedList<int> FavouriteNumbers { get; set; }
+
+            public Developer(HashSet<string> skills, LinkedList<int> favouriteNumbers)
+            {
+                Skills = skills;
+                FavouriteNumbers = favouriteNumbers;
+            }
+        }
+
+        [Test]
+        public void CanOutputWithCustomTypeMapping()
+        {
+            var output = new StringBuilder();
+            output.Append(
+                new TypeScripter.Scripter()
+                    .WithTypeMapping(new TsInterface(new TsName("Array")), typeof(HashSet<>))
+                    .WithTypeMapping(new TsArray(TsPrimitive.String, 1), typeof(LinkedList<int>))
+                    .AddType(typeof(Developer))
+            );
+
+            output.AppendLine();
+            output.AppendLine("var dev: TypeScripter.Tests.Developer");
+            output.AppendLine("var skills: string[] = dev.Skills;");
+            output.AppendLine("var favNumbers: string[] = dev.FavouriteNumbers;");
+
+            ValidateTypeScript(output);
+        }
+    }
+}
+

--- a/Src/TypeScripter.Tests/TypeScripter.Tests.csproj
+++ b/Src/TypeScripter.Tests/TypeScripter.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Examples\Ex3.Generics.cs" />
     <Compile Include="Examples\Ex2.Inheritance.cs" />
     <Compile Include="Examples\Ex1.BasicUsage.cs" />
+    <Compile Include="RegisterTypeMapping.cs" />
     <Compile Include="Fields.cs" />
     <Compile Include="Inheritance.cs" />
     <Compile Include="Generics.cs" />

--- a/Src/TypeScripter/Scripter.cs
+++ b/Src/TypeScripter/Scripter.cs
@@ -147,6 +147,22 @@ namespace TypeScripter
         }
 
         /// <summary>
+        /// Registers custom type mapping
+        /// </summary>
+        /// <param name="tsType">The TypeScript type</param>
+        /// <param name="type">The native type</param>
+        /// <returns></returns>
+        public Scripter WithTypeMapping(TsType tsType, Type type)
+        {
+            if (this.TypeLookup.ContainsKey(type))
+            {
+                throw new ArgumentException("Mapping for " + type.FullName + " is already defined.", "type");
+            }
+            this.TypeLookup[type] = tsType;
+            return this;
+        }
+
+        /// <summary>
         /// Adds a particular type to be scripted
         /// </summary>
         /// <param name="type">The type</param>


### PR DESCRIPTION
I think it is last quite useful feature which I desire for TypeScripter. 

By having an option to call:

``` cs
 .WithTypeMapping()
```

we can register custom type mapping used in our application. 

It is also quite useful in scenarios I used in test case:

``` cs
  .WithTypeMapping(new TsInterface(new TsName("Array")), typeof(HashSet<>))
  .WithTypeMapping(new TsArray(TsPrimitive.String, 1), typeof(LinkedList<int>))
```

In first case we can register mapping for HashSet (generic one)  to Array. In second one we can even register mapping for generic type with type bound. 

With out this PR HashSet is assumed to be any (or it traverse to System assembly if we don't filter on type crawler). 

If you consider this feature to be to low level we can alternatively change visibility of types and do this by extending Scripter class manually by user. 
