### PR TITLE
render nullable fields as optional field / avoid System.Nullable

### DIFF
--- a/Src/TypeScripter.Tests/NullableTypes.cs
+++ b/Src/TypeScripter.Tests/NullableTypes.cs
@@ -9,6 +9,8 @@ namespace TypeScripter.Tests
     {
         public Enum1? Property1 { get; set; }
         public int? IntProperty { get; set; }
+
+        public long? LongField; // no get/set here
     }
 
     public enum Enum1
@@ -43,6 +45,7 @@ namespace TypeScripter.Tests
 
             Assert.True(output.Contains("const enum Enum1"), "Underlaying enum should be resolved");
             Assert.True(output.Contains("IntProperty?: number"));
+            Assert.True(output.Contains("LongField?: number"));
             Assert.True(output.Contains("Property1?: TypeScripter.Tests.Enum1"));
         }
 

--- a/Src/TypeScripter/Scripter.cs
+++ b/Src/TypeScripter/Scripter.cs
@@ -470,7 +470,22 @@ namespace TypeScripter
         /// <returns></returns>
         protected virtual TsProperty Resolve(FieldInfo field)
         {
-            return new TsProperty(GetName(field), Resolve(field.FieldType));
+            TsType propertyType;
+            bool optional = false;
+            var fieldTypeInfo = field.FieldType.GetTypeInfo();
+            if (fieldTypeInfo.IsGenericType && fieldTypeInfo.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                var genericArguments = fieldTypeInfo.GetGenericArguments();
+                propertyType = this.Resolve(genericArguments[0]);
+                optional = true;
+            }
+            else
+            {
+                propertyType = Resolve(field.FieldType);
+            }
+
+
+            return new TsProperty(GetName(field), propertyType, optional);
         }
 
         /// <summary>


### PR DESCRIPTION
Small fix to: https://github.com/cjlpowers/TypeScripter/pull/7

We had proper resolution for nullable properties, but we luck support for fields. This PR fixes it. 