### PR TITLE
Treat all IEnumerable<T> Properties as arrays

### DIFF
--- a/Src/TypeScripter/Scripter.cs
+++ b/Src/TypeScripter/Scripter.cs
@@ -435,6 +435,11 @@ namespace TypeScripter
                 tsType = TsPrimitive.Any;
             else if (type.IsGenericParameter)
                 tsType = new TsGenericType(new TsName(type.Name));
+            else if (typeInfo.ImplementedInterfaces.Contains(typeof(IEnumerable)) && typeInfo.IsGenericType && !typeInfo.IsGenericTypeDefinition)
+            {
+                var elementType = this.Resolve(typeInfo.GetGenericArguments()[0]);
+                tsType = new TsArray(elementType, 1);
+            }
             else if (typeInfo.IsGenericType && !typeInfo.IsGenericTypeDefinition)
             {
                 var tsGenericTypeDefinition = Resolve(type.GetGenericTypeDefinition());


### PR DESCRIPTION
Often times, there are classes that have properties of type `IEnumerable<T>`. The way `TypeScripter` currently deals with this is by generating a definition for `IEnumerable<T>` in Typescript. I feel like this isn't really the intent of a user trying to convert a C# class to Typescript. This PR makes it so that any property that implements `IEnumerable<T>` will get emitted as an array of that type in Typescript.