### PR TITLE
Add ability to make all properties camel case

### DIFF
--- a/Src/TypeScripter/Scripter.cs
+++ b/Src/TypeScripter/Scripter.cs
@@ -265,6 +265,15 @@ namespace TypeScripter
             this.TypeFilter = filter;
             return this;
         }
+
+        /// <summary>
+        /// Use lower camel case for properties
+        /// </summary>
+        public Scripter LowerCamelCaseProperties()
+        {
+            this.Formatter.LowerCamelCaseProperties = true;
+            return this;
+        }
         #endregion
 
         #region Type Generation

--- a/Src/TypeScripter/TypeScript/TsFormatter.cs
+++ b/Src/TypeScripter/TypeScript/TsFormatter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -102,6 +103,14 @@ namespace TypeScripter.TypeScript
         /// Enums are represented as strings not as numbers
         /// </summary>
         public bool EnumsAsString
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Use lower camel case for properties
+        /// </summary>
+        public bool LowerCamelCaseProperties
         {
             get; set;
         }
@@ -221,11 +230,16 @@ namespace TypeScripter.TypeScript
         {
             using (var sbc = new StringBuilderContext(this))
             {
-                this.Write("{0}{1}: {2};", Format(property.Name), property.Optional?"?":"", Format(property.Type));
-                return sbc.ToString();
+                this.Write("{0}{1}: {2};", Format(property.Name), property.Optional ? "?" : "", Format(property.Type));
+                var result = sbc.ToString();
+                if (!LowerCamelCaseProperties)
+                {
+                    return result;
+                }
+                return char.ToLower(result[0]) + (result.Length == 1 ? String.Empty : result.Substring(1));
             }
         }
-        
+
         /// <summary>
         /// Formats an indexer property
         /// </summary>


### PR DESCRIPTION
In C# the convention is to use `UpperCamelCase` for property names. In JavaScript/Typescript however, the convention is to use `lowerCamelCase`. Currently, TypeScripter outputs property names exactly as is, which causes some friction on the front end in Typescript. This PR adds the ability to opt in to using `lowerCamelCase` for property names.

Note: I tried following the coding style as best I could.